### PR TITLE
add docker-clean for debian image

### DIFF
--- a/library/debian/buster-slim/make_rootfs.sh
+++ b/library/debian/buster-slim/make_rootfs.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
+set -e
 
 : ${DISTRO:="loongnix"}
 : ${RELEASE:=DaoXiangHu-stable}
 : ${MIRROR_ADDRESS:=http://pkg.loongnix.cn/loongnix}
 : ${ROOTFS:="rootfs.tar.gz"}
+: ${APT_CONF_URL:="https://raw.githubusercontent.com/GoogleContainerTools/base-images-docker/master/debian/reproducible/overlay/etc/apt/apt.conf.d/"}
 
 WKDIR=$1
 cd ${WKDIR?}
 
 apt update -y
-apt install -y debootstrap
+apt install -y debootstrap curl
 if [ ! -f /usr/share/debootstrap/scripts/$RELEASE ]; then
 	ln -s /usr/share/debootstrap/scripts/sid /usr/share/debootstrap/scripts/$RELEASE
 fi
@@ -43,6 +45,18 @@ for slimExclude in "${slimExcludes[@]}"; do
                         -not "${findMatchIncludes[@]}" \
                         -exec rm -f '{}' ';'
         }
+done
+
+# https://github.com/GoogleContainerTools/base-images-docker/tree/master/debian/reproducible/overlay/etc/apt/apt.conf.d
+apt_conf=(
+    apt-retry
+    docker-autoremove-suggests
+    docker-clean
+    docker-gzip-indexes
+)
+
+for apt_file in ${apt_conf[@]};do
+    curl -o $TMPDIR/etc/apt/apt.conf.d/${apt_file} -sSL ${APT_CONF_URL}/${apt_file}
 done
 
 while [ "$(


### PR DESCRIPTION
避免以此的基础镜像忘记清理缓存
```
$ docker run --rm debian:11 ls -l /etc/apt/apt.conf.d/
total 24
-rw-r--r-- 1 root root  630 Jun 10  2021 01autoremove
-rw-r--r-- 1 root root  182 Jun 10  2021 70debconf
-rw-r--r-- 1 root root  754 Dec 20  2021 docker-autoremove-suggests
-rw-r--r-- 1 root root 1175 Dec 20  2021 docker-clean
-rw-r--r-- 1 root root  481 Dec 20  2021 docker-gzip-indexes
-rw-r--r-- 1 root root  269 Dec 20  2021 docker-no-languages
```