### PR TITLE
py: change COPY to wget to remove the cache in overlay

### DIFF
--- a/library/python/3.7.10/Dockerfile
+++ b/library/python/3.7.10/Dockerfile
@@ -9,8 +9,6 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-COPY Python-3.7.10.tar.xz python.tar.xz
-
 # runtime dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -20,8 +18,8 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-
-ENV PYTHON_VERSION 3.7.10
+ARG PYTHON_VERSION 3.7.10
+ENV PYTHON_VERSION ${PYTHON_VERSION}
 
 RUN set -eux; \
 	\
@@ -49,6 +47,7 @@ RUN set -eux; \
 		xz-utils \
 		zlib1g-dev \
 	; \
+	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -133,7 +132,8 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+	apt-get clean; \
+	rm -rf /var/lib/apt/lists/* /var/cache/apt/* /tmp/*; \
 	\
 	python3 --version
 
@@ -148,11 +148,23 @@ RUN set -eux; \
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 21.1.3
-
-COPY get-pip.py /
+# https://github.com/pypa/get-pip
+ARG PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/0d8570dc44796f4369b652222cf176b3db6ac70e/public/get-pip.py
+ENV PYTHON_GET_PIP_URL ${PYTHON_GET_PIP_URL}
 
 RUN set -eux; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	\
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	\
+		apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apt-get clean; \
+	rm -rf /var/lib/apt/lists/* /var/cache/apt/* /tmp/*; \
 	export PYTHONDONTWRITEBYTECODE=1; \
 	\
 	python get-pip.py \

--- a/library/python/3.7.10/Makefile
+++ b/library/python/3.7.10/Makefile
@@ -13,13 +13,13 @@ PYTHON_GET_PIP_URL?=https://github.com/pypa/get-pip/raw/a1675ab6c2bd898ed82b1f58
 
 default: image
 
-download:
-	wget -O Python-$(PYTHON_VERSION).tar.xz "https://www.python.org/ftp/python/$(PYTHON_VERSION)/Python-$(PYTHON_VERSION).tar.xz"&& \
-	wget -O get-pip.py "$(PYTHON_GET_PIP_URL)"
-image: download
+image: 
 	docker build \
+		--build-arg PYTHON_VERSION=${PYTHON_VERSION} \
+		--build-arg PYTHON_GET_PIP_URL=${PYTHON_GET_PIP_URL} \
+		--build-arg http_proxy=$(http_proxy) \
+		--build-arg https_proxy=$(https_proxy) \
 		-t $(IMAGE) \
 		.
-
 push:
 	docker push $(IMAGE)

--- a/library/python/3.8.0-alpine/Dockerfile
+++ b/library/python/3.8.0-alpine/Dockerfile
@@ -8,7 +8,6 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
-COPY Python-3.8.0.tar.xz python.tar.xz
 
 # runtime dependencies
 RUN set -eux; \
@@ -17,7 +16,8 @@ RUN set -eux; \
 		wget \
 	;
 
-ENV PYTHON_VERSION 3.8.0
+ARG PYTHON_VERSION 3.8.0
+ENV PYTHON_VERSION ${PYTHON_VERSION}
 
 RUN set -eux; \
 	\
@@ -27,6 +27,7 @@ RUN set -eux; \
 		xz \
 	; \
 	\
+	wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz"; \
 	mkdir -p /usr/src/python; \
 	tar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \
 	rm python.tar.xz; \
@@ -62,7 +63,6 @@ RUN set -eux; \
 # update config.sub && config.guess
 	wget -O ./config.sub "git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD"; \
 	wget -O ./config.guess "git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD"; \
-
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \
@@ -113,10 +113,14 @@ RUN set -eux; \
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 19.3.1
-
-COPY get-pip.py /
+# https://github.com/pypa/get-pip
+ARG PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/ffe826207a010164265d9cc807978e3604d18ca0/get-pip.py
+ENV PYTHON_GET_PIP_URL ${PYTHON_GET_PIP_URL}
 
 RUN set -ex; \
+	\
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	\
 	export PYTHONDONTWRITEBYTECODE=1; \
 	\
 	python get-pip.py \

--- a/library/python/3.8.0-alpine/Makefile
+++ b/library/python/3.8.0-alpine/Makefile
@@ -13,12 +13,12 @@ PYTHON_GET_PIP_URL?=https://github.com/pypa/get-pip/raw/ffe826207a010164265d9cc8
 
 default: image
 
-download:
-	wget -O Python-$(PYTHON_VERSION).tar.xz "https://www.python.org/ftp/python/$(PYTHON_VERSION)/Python-$(PYTHON_VERSION).tar.xz"&& \
-	wget -O get-pip.py "$(PYTHON_GET_PIP_URL)"
-
-image: download
+image: 
 	docker build \
+		--build-arg PYTHON_VERSION=${PYTHON_VERSION} \
+		--build-arg PYTHON_GET_PIP_URL=${PYTHON_GET_PIP_URL} \
+		--build-arg http_proxy=$(http_proxy) \
+		--build-arg https_proxy=$(https_proxy) \
 		-t $(IMAGE) \
 		.
 


### PR DESCRIPTION
dive 分析 py 镜像存在浪费容量
```
dive cr.loongnix.cn/library/python:3.7.10
```
![KKLM7POU4 `QPL`W S~Y047](https://github.com/Loongson-Cloud-Community/dockerfiles/assets/18641678/03e1ef88-cff5-4932-bf2d-fe8a6545c146)
COPY 压缩包换成 wget ，避免overlay的upper层文件附带到镜像里
最好是在 https://github.com/Loongson-Cloud-Community/dockerfiles/issues/25 解决后再合入此pr