### PR TITLE
fix coredns 1.10.1 user

### DIFF
--- a/kubernetes/coredns/v1.10.1/0001-support-loong64.patch
+++ b/kubernetes/coredns/v1.10.1/0001-support-loong64.patch
@@ -1,25 +1,27 @@
-From 5aac0c95ffd85ffe55c701b20f4407c42a2c8795 Mon Sep 17 00:00:00 2001
+From 01d85f2891347458120ef4c65211a06765747c9b Mon Sep 17 00:00:00 2001
 From: zhangguanzhang <zhangguanzhang@qq.com>
-Date: Fri, 28 Jul 2023 12:24:54 +0800
-Subject: [PATCH] Introduces the ARG in Dockerfile
+Date: Sat, 7 Oct 2023 10:35:21 +0800
+Subject: [PATCH] support loong64
 
 ---
- Dockerfile | 17 ++++++++++-------
- 1 file changed, 10 insertions(+), 7 deletions(-)
+ Dockerfile | 19 ++++++++++++-------
+ 1 file changed, 12 insertions(+), 7 deletions(-)
 
 diff --git a/Dockerfile b/Dockerfile
-index b840a57..5ff7982 100644
+index b840a577..4e4fdcf3 100644
 --- a/Dockerfile
 +++ b/Dockerfile
-@@ -1,4 +1,6 @@
+@@ -1,4 +1,8 @@
 -FROM --platform=$BUILDPLATFORM debian:stable-slim
 +ARG DEBIAN_IMAGE=debian:stable-slim
 +ARG BASE=gcr.io/distroless/static-debian11:nonroot
++ARG USER=nonroot
 +FROM ${DEBIAN_IMAGE} AS build
++
  SHELL [ "/bin/sh", "-ec" ]
  
  RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
-@@ -7,13 +9,14 @@ RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
+@@ -7,13 +11,14 @@ RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
             TERM=linux ; \
      apt-get -qq update ; \
      apt-get -yyqq upgrade ; \
@@ -37,7 +39,7 @@ index b840a57..5ff7982 100644
 +FROM ${BASE}
 +COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 +COPY --from=build /coredns /coredns
-+USER nonroot:nonroot
++USER ${USER}:${USER}
  EXPOSE 53 53/udp
  ENTRYPOINT ["/coredns"]
 -- 

--- a/kubernetes/coredns/v1.10.1/Makefile
+++ b/kubernetes/coredns/v1.10.1/Makefile
@@ -3,10 +3,10 @@
 REGISTRY?=cr.loongnix.cn
 ORGANIZATION?=coredns
 REPOSITORY?=coredns
-TAG?=v1.10.1
+TAG?=1.10.1
 LATEST?=true
 
-GO_IMG?=cr.loongnix.cn/library/golang:1.19
+GO_IMG?=cr.loongnix.cn/library/golang:1.20
 GOPROXY?=https://goproxy.cn,https://mirrors.aliyun.com/goproxy/,https://goproxy.io,direct
 
 IMAGE=$(REGISTRY)/$(ORGANIZATION)/$(REPOSITORY):$(TAG)
@@ -18,12 +18,12 @@ LATEST_IMAGE=$(REGISTRY)/$(ORGANIZATION)/$(REPOSITORY):latest
 # Be sure to fill in the follows!!!
 SOURCE_URL=https://github.com/coredns/coredns.git
 SOURCE=$(shell echo $(SOURCE_URL) | awk -F '/' '{print $$NF}' | awk -F '.' '{print $$1}')
-PATCH=0001-Introduces-the-ARG-in-Dockerfile.patch
+PATCH=0001-support-loong64.patch
 
 default: image
 
 src/$(SOURCE):
-	git clone -b $(TAG) --depth=1 $(SOURCE_URL) $@
+	git clone -b v$(TAG) --depth=1 $(SOURCE_URL) $@
 	cd $@ && \
 		git apply ../../$(PATCH)
 
@@ -40,6 +40,7 @@ image: src/$(SOURCE) build
 		-t $(IMAGE) \
 		--build-arg=DEBIAN_IMAGE=$(REGISTRY)/library/debian:buster \
 		--build-arg=BASE=$(REGISTRY)/library/debian:buster \
+		--build-arg=USER=nobody \
 		src/$(SOURCE)
 
 push:


### PR DESCRIPTION
修复 coredns 1.10.1 用户问题无法启动：
```
unable to find user nonroot: no matching entries in passwd file
```