### PR TITLE
slimify debian: remove loongson graphics

### DIFF
--- a/library/debian/buster-slim/.gitignore
+++ b/library/debian/buster-slim/.gitignore
@@ -1,1 +1,2 @@
 rootfs.tar.gz
+rootfs.tar.xz

--- a/library/debian/buster-slim/Makefile
+++ b/library/debian/buster-slim/Makefile
@@ -7,7 +7,7 @@ TAG?=buster-slim
 
 IMAGE=$(REGISTRY)/$(ORGANIZATION)/$(REPOSITORY):$(TAG)
 
-ROOTFS=rootfs.tar.gz
+ROOTFS=rootfs.tar.xz
 
 default: image
 
@@ -21,9 +21,8 @@ push:
 	docker push $(IMAGE)
 
 $(ROOTFS):
-	docker run -it --rm \
+	docker run --rm \
 		-v `pwd`:/wk \
-		--env https_proxy=$(https_proxy) \
-		--env http_proxy=$(http_proxy) \
+		--privileged \
 		cr.loongnix.cn/library/debian:buster \
-		/bin/bash -c "/wk/make_rootfs.sh /wk"
+		/bin/bash -c "/wk/make_rootfs.sh"

--- a/library/debian/buster-slim/make_rootfs.sh
+++ b/library/debian/buster-slim/make_rootfs.sh
@@ -4,17 +4,29 @@ set -e
 : ${DISTRO:="loongnix"}
 : ${RELEASE:=DaoXiangHu-stable}
 : ${MIRROR_ADDRESS:=http://pkg.loongnix.cn/loongnix}
-: ${ROOTFS:="rootfs.tar.gz"}
+: ${ROOTFS:="rootfs.tar.xz"}
 : ${APT_CONF_URL:="https://raw.githubusercontent.com/GoogleContainerTools/base-images-docker/master/debian/reproducible/overlay/etc/apt/apt.conf.d/"}
 
-WKDIR=$1
-cd ${WKDIR?}
+OUTPUT=$(cd "$(dirname $0)";pwd)
+cd ${OUTPUT?}
 
 apt update -y
-apt install -y debootstrap curl
+apt install -y debootstrap curl xz-utils
 if [ ! -f /usr/share/debootstrap/scripts/$RELEASE ]; then
 	ln -s /usr/share/debootstrap/scripts/sid /usr/share/debootstrap/scripts/$RELEASE
 fi
+
+# https://github.com/GoogleContainerTools/base-images-docker/tree/master/debian/reproducible/overlay/etc/apt/apt.conf.d
+apt_conf=(
+    apt-retry
+    docker-autoremove-suggests
+    docker-clean
+    docker-gzip-indexes
+)
+
+for apt_file in ${apt_conf[@]};do
+    curl -o $TMPDIR/etc/apt/apt.conf.d/${apt_file} -sSL ${APT_CONF_URL}/${apt_file}
+done
 
 TMPDIR=`mktemp -d`
 cp .slimify-includes $TMPDIR/.slimify-includes
@@ -26,6 +38,41 @@ chroot $TMPDIR debootstrap/debootstrap --second-stage
 # slimify
 slimIncludes=( $(sed '/^#/d;/^$/d' .slimify-includes | sort -u) )
 slimExcludes=( $(sed '/^#/d;/^$/d' .slimify-excludes | sort -u) )
+
+# package excludes
+pkgExcludes='loongnix-gpu-driver-service,loonggpu-compiler,loonggl-dev'
+pkgIncludes='libncursesw6,libseccomp2,sysvinit-utils'
+
+userExcludes=(
+  systemd-timesync
+  systemd-network
+  systemd-resolve
+)
+
+chroot $TMPDIR bash -c '
+  apt-get -o apt-get -o Acquire::Check-Valid-Until=false update -qq
+  if apt-mark --help &> /dev/null; then
+    apt-mark auto ".*" > /dev/null
+  fi
+  if [ -n "$1" ]; then
+    IFS=","; includePackages=( $1 ); unset IFS
+    apt-get install -y --no-install-recommends "${includePackages[@]}"
+  fi
+  if [ -n "$2" ]; then
+    IFS=","; excludePackages=( $2 ); unset IFS
+    apt-get autoremove -y --purge --allow-remove-essential "${excludePackages[@]}"
+  fi
+  for user in systemd-timesync systemd-network systemd-resolve; do
+      if id $user >/dev/null; then
+          userdel --force --remove $user
+      fi
+  done
+' -- $pkgIncludes $pkgExcludes
+
+for user in ${userExcludes[@]}; do
+    chroot $TMPDIR userdel --force --remove "${user}" \
+        || echo "${user} not found"
+done
 
 findMatchIncludes=()
 for slimInclude in "${slimIncludes[@]}"; do
@@ -48,17 +95,6 @@ for slimExclude in "${slimExcludes[@]}"; do
         }
 done
 
-# https://github.com/GoogleContainerTools/base-images-docker/tree/master/debian/reproducible/overlay/etc/apt/apt.conf.d
-apt_conf=(
-    apt-retry
-    docker-autoremove-suggests
-    docker-clean
-    docker-gzip-indexes
-)
-
-for apt_file in ${apt_conf[@]};do
-    curl -o $TMPDIR/etc/apt/apt.conf.d/${apt_file} -sSL ${APT_CONF_URL}/${apt_file}
-done
 
 while [ "$(
         chroot $TMPDIR \
@@ -69,4 +105,4 @@ while [ "$(
         )" -gt 0 ]; do true; done
 
 chroot $TMPDIR rm -rf /tmp/* /var/cache/apt/* /var/lib/apt/lists/*
-tar -zcvf $ROOTFS -C $TMPDIR .
+tar -cJf $ROOTFS -C $TMPDIR .


### PR DESCRIPTION
精简 debian:buster-slim 镜像，本地测试 rootfs.tar.xz 大小为 15M

基于 https://github.com/Loongson-Cloud-Community/dockerfiles/issues/25#issuecomment-1746139080 做了以下改动
1. 保留 utils-linux-extra
2. 删除 loonggl-dev
3. 新增 libncursesw6,libseccomp2,sysvinit-utils 和 x86 保持一致
4. rootfs 格式改为 rootfs.tar.xz
5. 构建脚本优化，不再传递 OUTPUT 路径