### PR TITLE
loongnix-server-8.4: change the compression method of rootfs to xz

### DIFF
--- a/loongson/loongnix-server/8.4/Makefile
+++ b/loongson/loongnix-server/8.4/Makefile
@@ -7,7 +7,7 @@ TAG?=8.4
 
 IMAGE=$(REGISTRY)/$(ORGANIZATION)/$(REPOSITORY):$(TAG)
 
-ROOTFS=Loongnix-server-8.4.0.rootfs.loongarch64.tar.gz
+ROOTFS=Loongnix-server-8.4.0.rootfs.loongarch64.tar.xz
 
 default: image
 


### PR DESCRIPTION
- 目前rootfs的压缩方式是gz，rootfs的大小已经超出了github的范围（50MB），并且出现警告。  
- 修改rootfs的压缩方式是xz， 显著的减少rootfs的大小。
- 修改前rootfs的大小为69MB， 修改后rootfs的大小为 43MB。
