### PR TITLE
feat: 移除 systemd-journal

### DIFF
--- a/library/debian/buster-slim/make_rootfs.sh
+++ b/library/debian/buster-slim/make_rootfs.sh
@@ -63,6 +63,11 @@ chroot $TMPDIR bash -c '
           userdel --force --remove $user
       fi
   done
+  for group in systemd-journal; do
+      if getent group $group >/dev/null; then
+          groupdel $group
+      fi
+  done
 ' -- $pkgIncludes $pkgExcludes
 
 findMatchIncludes=()


### PR DESCRIPTION
```sh
docker run --rm -it cr.loongnix.cn/library/debian:buster-slim bash
root@8d83c00bbd0d:/# cat /etc/group | grep systemd-journal
systemd-journal:x:101:
```
`systemd-journal` 占用了 `nginx` 的 `gid`，需要移除。

- https://github.com/nginxinc/docker-nginx/blob/master/stable/debian/Dockerfile#L16